### PR TITLE
feat: add docker and k8s deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log
+dist
+Dockerfile
+.dockerignore
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+
+# Build stage
+FROM node:18-alpine AS builder
+WORKDIR /app
+COPY package*.json yarn.lock* ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM node:18-alpine AS runner
+WORKDIR /app
+COPY --from=builder /app/dist ./dist
+COPY package*.json ./
+RUN npm ci --omit=dev
+CMD ["node", "dist/main"]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,27 @@ $ npm run test:e2e
 $ npm run test:cov
 ```
 
+## Docker
+
+This project includes a `Dockerfile` and a `docker-compose.yml` to build and run the application in containers.
+
+```bash
+# build image and start services
+docker-compose up --build
+
+# push the image to Docker Hub
+docker-compose push
+```
+
+## Kubernetes
+
+Kubernetes manifests are available in the `k8s/` directory. After pushing the image to Docker Hub, deploy with:
+
+```bash
+kubectl apply -f k8s/deployment.yaml
+kubectl apply -f k8s/service.yaml
+```
+
 ## Support
 
 Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    image: your-dockerhub-username/api-ediarista:latest
+    ports:
+      - '3000:3000'
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@db:5432/ediarista
+    depends_on:
+      - db
+  db:
+    image: postgres:14-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: ediarista
+    volumes:
+      - db-data:/var/lib/postgresql/data
+volumes:
+  db-data:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-ediarista
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: api-ediarista
+  template:
+    metadata:
+      labels:
+        app: api-ediarista
+    spec:
+      containers:
+        - name: api-ediarista
+          image: your-dockerhub-username/api-ediarista:latest
+          ports:
+            - containerPort: 3000
+          env:
+            - name: DATABASE_URL
+              value: postgres://postgres:postgres@db:5432/ediarista

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-ediarista
+spec:
+  selector:
+    app: api-ediarista
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3000
+  type: ClusterIP


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile
- introduce docker-compose with Postgres
- include Kubernetes manifests and docs

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf53fc98083288875c469398c32a7